### PR TITLE
Feature: progress bar and spotify player state notifications

### DIFF
--- a/src/components/hud/HUDSongProgress.js
+++ b/src/components/hud/HUDSongProgress.js
@@ -1,0 +1,73 @@
+import React from "react";
+import PropTypes from "prop-types";
+import SpotifySong from "./SpotifySong";
+import "../../css/hud/HUDSongProgress.css";
+
+const HUDSongProgress = props => {
+
+    const {
+        songObject,
+        positionInMilliseconds,
+        shouldDisplay
+    } = props;
+
+    if (!songObject) return null;
+
+    const {
+        name,
+        id,
+        img,
+        artist,
+        duration
+    } = songObject;
+
+    const percentage = positionInMilliseconds / duration * 100;
+
+    const barProperties = {
+        "width": `${percentage}%`
+    };
+
+    const componentStyle = {
+        "display": shouldDisplay ? "block" : "none"
+    };
+
+    return (
+        <div
+            className={"song-progress-bar-container"}
+            style={componentStyle}
+        >
+            <div id={"bar-wrapper"}>
+                <div
+                    id={"progress-bar"}
+                    style={barProperties}
+                />
+            </div>
+            <div className={"progress-bar-song-icon"}>
+                {
+                    <SpotifySong
+                        name={name}
+                        artist={artist}
+                        imgURL={img}
+                        id={id}
+                        size={"mini"}
+                    />
+                }
+            </div>
+        </div>
+    );
+
+};
+
+HUDSongProgress.propTypes = {
+    "songObject": PropTypes.shape({
+        "name": PropTypes.string,
+        "id": PropTypes.string,
+        "img": PropTypes.string,
+        "artist": PropTypes.array,
+        "duration": PropTypes.number
+    }),
+    "positionInMilliseconds": PropTypes.number.isRequired,
+    "shouldDisplay": PropTypes.bool.isRequired
+};
+
+export default HUDSongProgress;

--- a/src/components/hud/SpotifySong.js
+++ b/src/components/hud/SpotifySong.js
@@ -3,10 +3,16 @@ import PropTypes from "prop-types";
 import "../../css/hud/SpotifySong.css";
 import {trimEnd} from "../../utils/StringTools";
 
+const SongContainerClassMap = Object.freeze({
+    "small": "song-container-small",
+    "large": "song-container-large",
+    "mini": "song-container-mini"
+});
+
 /**
  * React element for rendering a song and handling clicks on that element to select a song.
  *
- * Two styles are supported. Props.size can be either "small" or "large"
+ * Two styles are supported. Props.size can be either "small", "large", or "mini"
  * @param {Object} props react properties
  * @constructor
  */
@@ -17,11 +23,10 @@ const SpotifySong = props => {
         id,
         imgURL,
         artist,
+        duration,
         handleClick,
         size
     } = props;
-
-    const sizeClassName = size === "small" ? "song-container-small" : "song-container-large";
 
     const renderArtistArray = arr => {
 
@@ -36,11 +41,12 @@ const SpotifySong = props => {
     };
 
     return (
-        <div className={`${sizeClassName} song-container`} onClick={() => handleClick({
+        <div className={`${SongContainerClassMap[size]} song-container`} onClick={() => handleClick({
             name,
             id,
             imgURL,
-            artist
+            artist,
+            duration
         })}>
             <img className="song-image" src={imgURL} alt={`Album cover for song ${name} by artist ${artist}`}/>
             <div className="song-data-container">
@@ -57,8 +63,9 @@ SpotifySong.defaultProps = {
     "id": "No ID Passed",
     "imgURL": "No image URL passed",
     "artist": "No Artist",
+    "duration": -1,
     "handleClick": () => {
-        throw new Error("No click handler passed");
+        console.log("Song clicked!");
     },
     "size": "small"
 };
@@ -68,6 +75,7 @@ SpotifySong.propTypes = {
     "id": PropTypes.string,
     "imgURL": PropTypes.string,
     "artist": PropTypes.array,
+    "duration": PropTypes.number,
     "handleClick": PropTypes.func,
     "size": PropTypes.string
 };

--- a/src/css/hud/HUDSongProgress.css
+++ b/src/css/hud/HUDSongProgress.css
@@ -1,0 +1,20 @@
+.song-progress-bar-container {
+    position: absolute;
+    width: 100%;
+}
+
+#bar-wrapper {
+    height: 2vw;
+}
+
+#progress-bar {
+    height: 100%;
+    background-color: blue;
+    transition: 3.5s all;
+}
+
+.progress-bar-song-icon {
+    position: fixed;
+    left: 3vw;
+    top: 3vw;
+}

--- a/src/css/hud/HUDSongProgress.css
+++ b/src/css/hud/HUDSongProgress.css
@@ -9,8 +9,8 @@
 
 #progress-bar {
     height: 100%;
-    background-color: blue;
-    transition: 3.5s all;
+    background-color: rgba(0, 0, 255, 0.9);
+    transition: 3.5s all linear;
 }
 
 .progress-bar-song-icon {

--- a/src/css/hud/SpotifySong.css
+++ b/src/css/hud/SpotifySong.css
@@ -16,7 +16,37 @@
     border-bottom: 10px solid;
 }
 
-.song-container-large {height: 30%;
+.song-container-mini {
+    height: 6vw;
+    width: 20vw;
+    margin: 0 auto 0.8vw auto;
+    cursor: pointer;
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: left;
+
+    border-color: darkred;
+    background-color: rgba(217, 87, 99, 0.3);
+    border-left: 10px inset red;
+    border-bottom: 10px solid;
+}
+
+.song-container-mini .song-data-container .song-name {
+    font-size: 1.4vw;
+    white-space: nowrap;
+    margin-block-end: 0.4vw;
+}
+
+.song-container-mini .song-data-container .song-artist {
+    font-size: 0.9vw;
+    white-space: nowrap;
+    margin-block-start: 0;
+}
+
+.song-container-large {
+    height: 30%;
     border-radius: 5px;
     display: flex;
     justify-content: left;

--- a/src/css/hud/SpotifySong.css
+++ b/src/css/hud/SpotifySong.css
@@ -18,7 +18,8 @@
 
 .song-container-mini {
     height: 6vw;
-    width: 20vw;
+    width: auto;
+    padding-right: 1.2vw;
     margin: 0 auto 0.8vw auto;
     cursor: pointer;
 

--- a/src/pages/hud/HUDSongSearchMenu.js
+++ b/src/pages/hud/HUDSongSearchMenu.js
@@ -48,11 +48,12 @@ class HUDSongSearchMenu extends Component {
 
         // for each item, collect URI, song name, artist name, album image
         // eslint-disable-next-line max-params
-        const createTrackObject = (id, name, artist, img) => ({
+        const createTrackObject = (id, name, artist, img, duration) => ({
             name,
             artist,
             img,
-            id
+            id,
+            duration
         });
 
         const newTrackArray = items.map(item => {
@@ -61,8 +62,9 @@ class HUDSongSearchMenu extends Component {
             const songName = item.name;
             const artistNames = dotProp.get(item, "artists").map(artist => artist.name);
             const imgURL = dotProp.get(item, "album.images")[0].url;
+            const duration = dotProp.get(item, "duration_ms");
 
-            return createTrackObject(id, songName, artistNames, imgURL);
+            return createTrackObject(id, songName, artistNames, imgURL, duration);
 
         });
 
@@ -91,6 +93,7 @@ class HUDSongSearchMenu extends Component {
                 name={song.name}
                 artist={song.artist}
                 imgURL={song.img}
+                duration={song.duration}
                 id={song.id}
                 key={song.id}
                 handleClick={() => this.props.selectSong(song)}

--- a/src/utils/SpotifyService.js
+++ b/src/utils/SpotifyService.js
@@ -113,6 +113,16 @@ class SpotifyService {
 	}
 
 	/**
+	 * Getter for current state of spotify player.
+	 * @returns {Promise} contains the player state object
+	 */
+	get playerState() {
+		if (this.player) return this.player.getCurrentState();
+
+		return null;
+	}
+
+	/**
 	 * Refreshes the user token.
 	 * @param {String} refreshToken refresh token received from Spotify
 	 * @returns {JSON} JSON returned from query.
@@ -159,12 +169,12 @@ class SpotifyService {
 
 	/**
 	 * Plays a song on the current active player with a given spotify URI.
-	 * @param {String} id the Spotify track ID of the song. Can be acquired through search params.
+	 * @param {String} songID the Spotify track ID of the song. Can be acquired through search params.
 	 * @returns {void}
 	 */
-	play(id) {
+	play(songID) {
 
-		const uri = `spotify:track:${id}`;
+		const uri = `spotify:track:${songID}`;
 
 		if (!this.player) throw new Error("Player not initialized.");
 

--- a/src/utils/SpotifyService.js
+++ b/src/utils/SpotifyService.js
@@ -50,6 +50,14 @@ class SpotifyService {
 				log("PLAYER_READY", `Spotify player ready to stream songs on ${device_id}`, $spotifyServiceStateNotifier);
 			});
 
+			// check for player state updates and notify them
+			this.player.addListener("player_state_changed", webPlaybackStateObject => log(
+				"PLAYER_STATE_CHANGED",
+				webPlaybackStateObject,
+				"Spotify player state changed!",
+				$spotifyServiceStateNotifier
+			));
+
 			// TODO: add listener for error and automatically refresh token
 
 		};

--- a/src/utils/TransitionUtils.js
+++ b/src/utils/TransitionUtils.js
@@ -14,14 +14,18 @@ const TransitionEnums = {
  */
 const Transition = {
     "in": subject => {
-        subject.next({
-            "position": TransitionEnums.IN
-        });
+        if (subject) {
+            subject.next({
+                "position": TransitionEnums.IN
+            });
+        } else console.error("Invalid subject!");
     },
     "out": subject => {
-        subject.next({
-            "position": TransitionEnums.OUT
-        });
+        if (subject) {
+            subject.next({
+                "position": TransitionEnums.OUT
+            });
+        } else console.error("Invalid subject!");
     }
 };
 


### PR DESCRIPTION
**React Components**
Added progress bar
--> Added another SpotifySong component CSS option for displaying currently playing song
Added progress bar auto-updating by checking Spotify Web Player state
--> On play, bar periodically checks state for position
--> On pause or change, periodic checks are stopped
Added Game state change requests based on Spotify Web Player State changes
--> External pausing sends a `PAUSE` request
--> External song change sends an `IDLE` request (and will transition back to main menu with an error)
--> Random state change notifications simply update the state of the bar

**SpotifyService.js**
Now notifies player state changes using **log()**